### PR TITLE
 Ensure `mlfmu build` runs on Ubuntu 20.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the [mlfmu] project will be documented in this file.<br>
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [1.0.2]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ### Changed
 
+* Added checks for Windows vs Linux and fixed compilation for Linux, tested with Ubuntu 20.04.
+
+## [1.0.1]
+
+### Changed
+
 * Update generated docs; cleaning, fix for warnings, add missing pages and info, update authors and maintainers.
 * Add where the source code for cppfmu can be found, add third party license.
 * Added missing unit tests for the template data generated when building the FMU.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ### Changed
 
-* Added checks for Windows vs Linux and fixed compilation for Linux, tested with Ubuntu 20.04.
+* Added checks for Windows vs Linux and fixed compilation for Linux/MacOS, updated README. Tested with Ubuntu 20.04, Ubuntu 22.04 and MacOS 14.4.
 
 ## [1.0.1]
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ MLFMU serves as a tool for developers looking to integrate machine learning mode
 pip install mlfmu
 ```
 
+You may need to run `conan profile detect` before running the tool. See the notes further down in this README w.r.t. required cppstd version for Windows/Linux/MacOS.
+
 ## Creating ML FMUs
 
 ### Create your own ML model
@@ -142,6 +144,8 @@ For advanced usage options, e.g. editing the generated FMU source code, or using
 
 ## Development Setup
 
+If you just want to use `mlfmu`, you do not need to do the following steps. This is for those aiming to do development in this repo.
+
 ### 1. Install uv
 
 This project uses `uv` as package manager.
@@ -166,7 +170,7 @@ Once installed, you can update `uv` to its latest version, anytime, by running:
 uv self update
 ```
 
-### 2. Install Visual Studio Build Tools
+### 2. (Windows) Install Visual Studio Build Tools
 
 We use conan for building the FMU. For the conan building to work later on, you will need the Visual Studio Build tools 2022 to be installed. It is best to do this **before** installing conan (which gets installed as part of the package dependencies, see step 5). You can download and install the Build Tools for VS 2022 (for free) from <https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022>.
 
@@ -203,7 +207,11 @@ It allows the dependency resolver to upgrade dependencies to newer versions, whi
 uv sync -p 3.12 -U
 ```
 
-> Note: At this point, you should have conan installed. You will want to make sure it has the correct build profile. You can auto-detect and create the profile by running `conan profile detect`. After this, you can check the profile in `C:\Users\<USRNAM>\.conan2\profiles\.default` (replace `<USRNAM>` with your username). You want to have: `compiler=msvc`, `compiler.cppstd=17`, `compiler.version=193` (for Windows).
+> Note: At this point, you should have conan installed. You will want to make sure it has the correct build profile. You can auto-detect and create the profile by running `conan profile detect`.
+After this, you can check the profile:<br/>
+.. on Windows: in `C:\Users\<USRNAM>\.conan2\profiles\.default` (replace `<USRNAM>` with your username). You want to have: `compiler=msvc`, `compiler.cppstd=17`, `compiler.version=193`.<br/>
+.. on Linux: in `~/.conan2/profiles/default`, you will need at least `compiler.cppstd=gnu17` and `compiler.libcxx=libstdc++11`.
+.. on MacOS: in `~/.conan2/profiles/default`, you will need at least `compiler.cppstd=gnu20` (tested with `compiler.version=14`).
 
 ### 5. (Optional) Activate the virtual environment
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ copyright = "2024, DNV AS. All rights reserved."
 author = "Kristoffer Skare, Jorge Luis Mendez, Stephanie Kemna, Melih Akdag"
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.1"
+release = "1.0.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ copyright = "2024, DNV AS. All rights reserved."
 author = "Kristoffer Skare, Jorge Luis Mendez, Stephanie Kemna, Melih Akdag"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.6"
+release = "1.0.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/mlfmu/fmu_build/CMakeLists.txt
+++ b/src/mlfmu/fmu_build/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.24)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 project(cpp-fmus)

--- a/src/mlfmu/fmu_build/templates/onnx_fmu/onnxFmu.hpp
+++ b/src/mlfmu/fmu_build/templates/onnx_fmu/onnxFmu.hpp
@@ -30,8 +30,8 @@ class OnnxFmu : public cppfmu::SlaveInstance
 public:
     OnnxFmu(cppfmu::FMIString fmuResourceLocation);
 
-    // New functions for the OnnxTemplate class
-    std::wstring formatOnnxPath(cppfmu::FMIString fmuResourceLocation);
+    void formatOnnxPath(cppfmu::FMIString fmuResourceLocation);
+
     void CreateSession();
     bool SetOnnxInputs();
     bool GetOnnxOutputs();
@@ -55,7 +55,14 @@ private:
     Ort::Env env;
     Ort::RunOptions run_options;
     Ort::Session session_ {nullptr};
+
+    // std::wstring onnxPath_;
+    // store path as wstring for Windows or as char * for Linux
+#ifdef _WIN32
     std::wstring onnxPath_;
+#else
+    std::string onnxPath_;
+#endif
 
     std::string inputName_ {ONNX_INPUT_NAME};
     std::array<int64_t, 2> inputShape_ {1, NUM_ONNX_INPUTS};

--- a/src/mlfmu/fmu_build/templates/onnx_fmu/onnxFmu.hpp
+++ b/src/mlfmu/fmu_build/templates/onnx_fmu/onnxFmu.hpp
@@ -32,6 +32,7 @@ public:
 
     void formatOnnxPath(cppfmu::FMIString fmuResourceLocation);
 
+    // New functions for the OnnxTemplate class
     void CreateSession();
     bool SetOnnxInputs();
     bool GetOnnxOutputs();
@@ -56,7 +57,6 @@ private:
     Ort::RunOptions run_options;
     Ort::Session session_ {nullptr};
 
-    // std::wstring onnxPath_;
     // store path as wstring for Windows or as char * for Linux
 #ifdef _WIN32
     std::wstring onnxPath_;

--- a/src/mlfmu/utils/builder.py
+++ b/src/mlfmu/utils/builder.py
@@ -340,7 +340,9 @@ def build_fmu(
         f"-DFMU_NAMES={fmu_name}",
         f"-DFMU_SOURCE_PATH={fmu_src_path.parent!s}",
     ]
-    cmake_command = ["cmake", *cmake_set_folders, "--preset", "conan-default"]
+    # Windows vs Linux
+    conan_preset = "conan-default" if os.name == "nt" else "conan-release"
+    cmake_command = ["cmake", *cmake_set_folders, "--preset", conan_preset]
     cmake_build_command = ["cmake", "--build", ".", "-j", "14", "--config", "Release"]
 
     # Change directory to the build folder


### PR DESCRIPTION
## Description

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- Example: Resolves #15 -->
Resolves #79 

<!-- A brief summary of the change and which issue is fixed. -->
<!-- What is the current behavior (pre-fix) and what is the new expected behavior? -->
Added checks for Windows vs Linux - required a different conan_preset and different way to call Ort::Session::Session.

<!-- List any dependencies that are required for this change (if any) -->

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes.-->
<!-- List any relevant details for your test configuration.-->

- [x] Tested on Ubuntu 20.04, running mlfmu build for WindGenerator and WindToPower
- [x] Tested on Windows, running mlfmu build for WindGenerator and WindToPower

## Developer Checklist (before requesting PR review)

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules

I have:

- [x] commented my code, particularly in hard-to-understand areas
- [x] performed a self-review of my own code
- [x] not committed unnecessary formatting changes, thereby occluding the actual changes (e.g. change of tab spacing, eol, etc.)
- [n/a] made corresponding changes to the documentation
- [x] added change to CHANGELOG.md
- [n/a?] added tests that prove my fix is effective or that my feature works (for core features)

## Reviewer checklist

I have:

- [ ] have performed a review of the code
- [ ] tested that the software still works as expected
- [ ] checked updates to documentation
- [ ] checked that the CHANGELOG is updated
