### PR TITLE
Fix outputs in generated `modelDescription.xml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ### Changed
 
 * Generation of modelDescription.xml file to correctly generate tags for each output with 1-indexed indexes and InitialUnknowns tags
+* Generation of modelDescription.xml adds the variables (inputs, parameters and outputs) in the orderer of their valueReference. This is for the indexing to work correctly
 
 ## [1.0.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the [mlfmu] project will be documented in this file.<br>
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Changed
+
+* Generation of modelDescription.xml file to correctly generate tags for each output with 1-indexed indexes and InitialUnknowns tags
+
 ## [1.0.2]
 
 ### Changed

--- a/src/mlfmu/utils/fmi_builder.py
+++ b/src/mlfmu/utils/fmi_builder.py
@@ -97,7 +97,8 @@ def generate_model_description(fmu_model: FmiModel) -> ElementTree:
 
         # Appending output to <Outputs> inside <ModelStructure>
         if var.causality == FmiCausality.OUTPUT:
-            _ = SubElement(outputs, "Unknown", {"index": str(var.variable_reference)})
+            # Index is 1-indexed for <Unknown> tag
+            _ = SubElement(outputs, "Unknown", {"index": str(var.variable_reference + 1)})
 
     # Create XML tree containing root element and pretty format its contents
     xml_tree = ElementTree(root)

--- a/src/mlfmu/utils/fmi_builder.py
+++ b/src/mlfmu/utils/fmi_builder.py
@@ -76,6 +76,7 @@ def generate_model_description(fmu_model: FmiModel) -> ElementTree:
     # <ModelStructure> tag with <Outputs> tab inside --> Append all outputs
     model_structure = SubElement(root, "ModelStructure")
     outputs = SubElement(model_structure, "Outputs")
+    initial_unknowns = SubElement(model_structure, "InitialUnknowns")
 
     for var in fmu_model.get_fmi_model_variables():
         # XML variable attributes
@@ -95,10 +96,13 @@ def generate_model_description(fmu_model: FmiModel) -> ElementTree:
         # FMI variable type element
         _ = SubElement(var_elem, var.type.value.capitalize(), var_type_attrs)
 
-        # Appending output to <Outputs> inside <ModelStructure>
+        # Adding outputs inside <ModelStructure>
         if var.causality == FmiCausality.OUTPUT:
             # Index is 1-indexed for <Unknown> tag
-            _ = SubElement(outputs, "Unknown", {"index": str(var.variable_reference + 1)})
+            unknown_attributes = {"index": str(var.variable_reference + 1)}
+            # For each output create an <Unknown> tag inside both <Outputs> and <InitialUnknowns>
+            _ = SubElement(outputs, "Unknown", unknown_attributes)
+            _ = SubElement(initial_unknowns, "Unknown", unknown_attributes)
 
     # Create XML tree containing root element and pretty format its contents
     xml_tree = ElementTree(root)

--- a/src/mlfmu/utils/fmi_builder.py
+++ b/src/mlfmu/utils/fmi_builder.py
@@ -78,7 +78,14 @@ def generate_model_description(fmu_model: FmiModel) -> ElementTree:
     outputs = SubElement(model_structure, "Outputs")
     initial_unknowns = SubElement(model_structure, "InitialUnknowns")
 
-    for var in fmu_model.get_fmi_model_variables():
+    # Get all variables to add them inside the <ModelVariables> tag
+    model_variables = fmu_model.get_fmi_model_variables()
+
+    # The variables needs to be added in the order of their valueReference
+    sorted_model_variables = sorted(model_variables, key=lambda x: x.variable_reference)
+
+    # Add each variable inside the <ModelVariables> tag
+    for var in sorted_model_variables:
         # XML variable attributes
         var_attrs = {
             "name": var.name,

--- a/tests/utils/test_modelDescription_builder.py
+++ b/tests/utils/test_modelDescription_builder.py
@@ -193,5 +193,6 @@ def test_generate_model_description_output():
     output_variables = [var for var in variables if var.attrib.get("causality") == "output"]
     outputs_registered = xml_structure.findall(".//Outputs/Unknown")
 
-    assert output_variables[0].attrib["valueReference"] == outputs_registered[0].attrib["index"]
-    assert output_variables[1].attrib["valueReference"] == outputs_registered[1].attrib["index"]
+    # The index should be the valueReference + 1
+    assert int(output_variables[0].attrib["valueReference"]) + 1 == int(outputs_registered[0].attrib["index"])
+    assert int(output_variables[1].attrib["valueReference"]) + 1 == int(outputs_registered[1].attrib["index"])

--- a/tests/utils/test_modelDescription_builder.py
+++ b/tests/utils/test_modelDescription_builder.py
@@ -56,13 +56,14 @@ def test_generate_model_description_with_internal_state_params():
     variables = xml_structure.findall(".//ScalarVariable")
 
     assert xml_structure.getroot().tag == "fmiModelDescription"
-    assert variables[0].attrib["name"] == "state1"
-    assert variables[0].attrib["causality"] == "parameter"
-    assert variables[0][0].tag == "Real"
-    assert variables[0][0].attrib["start"] == "0.0"
 
-    assert variables[1].attrib["name"] == "output1"
-    assert variables[1].attrib["causality"] == "output"
+    assert variables[0].attrib["name"] == "output1"
+    assert variables[0].attrib["causality"] == "output"
+
+    assert variables[1].attrib["name"] == "state1"
+    assert variables[1].attrib["causality"] == "parameter"
+    assert variables[1][0].tag == "Real"
+    assert variables[1][0].attrib["start"] == "0.0"
 
 
 def test_generate_vector_ports():


### PR DESCRIPTION
## Description

Resolves #86 

Currently the generated FMUs does not pass the [fmu checker](https://fmu-check.herokuapp.com/).
This is now fixed by making two changes to the generation of the `modelDescription.xml`:
1. Adding the missing <InitialUnknowns> tag for the outputs
2. Changing attribute `index` for <Unknown> to be 1-indexed from being 0-indexed.
3. Change the order of the variables to be added sorted by their valueReference

## How Has This Been Tested?

- [x] Generated the example FMUs and checked them using the [fmu checker](https://fmu-check.herokuapp.com/).

## Screenshots (if appropriate)

## Developer Checklist (before requesting PR review)

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

I have:

- [x] commented my code, particularly in hard-to-understand areas
- [x] performed a self-review of my own code
- [x] not committed unnecessary formatting changes, thereby occluding the actual changes (e.g. change of tab spacing, eol, etc.)
- [ ] made corresponding changes to the documentation
- [x] added change to CHANGELOG.md
- [ ] added tests that prove my fix is effective or that my feature works (for core features)

## Reviewer checklist

I have:

- [x] performed a self-review of my own code have performed a review of the code
- [x] tested that the software still works as expected
- [x] checked updates to documentation
- [x] checked that the CHANGELOG is updated
