### PR TITLE
Remove CI badge and change documentation badge link wrt building of GitHub pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![pypi](https://img.shields.io/pypi/v/mlfmu.svg?color=blue)](https://pypi.python.org/pypi/mlfmu)
 [![versions](https://img.shields.io/pypi/pyversions/mlfmu.svg?color=blue)](https://pypi.python.org/pypi/mlfmu)
 [![license](https://img.shields.io/pypi/l/mlfmu.svg)](https://github.com/dnv-opensource/mlfmu/blob/main/LICENSE)
-![ci](https://img.shields.io/github/actions/workflow/status/dnv-opensource/mlfmu/.github%2Fworkflows%2Fnightly_build.yml?label=ci)
-[![docs](https://img.shields.io/github/actions/workflow/status/dnv-opensource/mlfmu/.github%2Fworkflows%2Fpush_to_release.yml?label=docs)][mlfmu_docs]
+[![docs](https://github.com/dnv-opensource/mlfmu/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/dnv-opensource/mlfmu/actions/workflows/pages/pages-build-deployment)
+
 
 # mlfmu
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![pypi](https://img.shields.io/pypi/v/mlfmu.svg?color=blue)](https://pypi.python.org/pypi/mlfmu)
 [![versions](https://img.shields.io/pypi/pyversions/mlfmu.svg?color=blue)](https://pypi.python.org/pypi/mlfmu)
 [![license](https://img.shields.io/pypi/l/mlfmu.svg)](https://github.com/dnv-opensource/mlfmu/blob/main/LICENSE)
-[![docs](https://github.com/dnv-opensource/mlfmu/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/dnv-opensource/mlfmu/actions/workflows/pages/pages-build-deployment)
+[![docs](https://github.com/dnv-opensource/mlfmu/actions/workflows/pages/pages-build-deployment/badge.svg)](https://dnv-opensource.github.io/mlfmu/README.html)
 
 
 # mlfmu


### PR DESCRIPTION
Remove CI badge (not currently active) and update docs badge links in README.

## Description

CI and docs badge were showing as failing - we don't have CI (nightly build) active, so badge removed, and updated the other one to the docs action that we run for gh-pages (badge code from GitHub).
